### PR TITLE
Редирект пользователя после логина или регистрации на нужную страницу

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -5,17 +5,23 @@ import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import AuthWrapper from '@/components/auth-wrapper/AuthWrapper';
 import { useLoginMutation } from '@/store/api';
 import { PAGES } from '@/config/pages.config';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
 export default function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [login, { isLoading: loginLoading }] = useLoginMutation();
 
   const onFinish = async (values: any) => {
     try {
       await login(values).unwrap();
-      router.replace(PAGES.HOME);
+
+      // Получаем URL для перенаправления из параметров запроса
+      const returnUrl = searchParams.get('returnUrl');
+      const redirectTo = returnUrl ? decodeURIComponent(returnUrl) : PAGES.HOME;
+
+      router.replace(redirectTo);
     } catch (err) {
       console.log('error');
       console.log(err);
@@ -45,7 +51,7 @@ export default function LoginForm() {
           <Button block type="primary" htmlType="submit" loading={loginLoading}>
             Войти
           </Button>
-          или <Link href={PAGES.REGISTER}>Зарегистрироваться!</Link>
+          или <Link href={`${PAGES.REGISTER}${searchParams.get('returnUrl') ? `?returnUrl=${searchParams.get('returnUrl')}` : ''}`}>Зарегистрироваться!</Link>
         </Form.Item>
       </Form>
     </AuthWrapper>

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -5,11 +5,12 @@ import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import AuthWrapper from '@/components/auth-wrapper/AuthWrapper';
 import { useRegisterMutation } from '@/store/api';
 import { PAGES } from '@/config/pages.config';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
 export default function RegisterForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [register, { isLoading: registerLoading }] = useRegisterMutation();
 
   const onFinish = async (values: any) => {
@@ -21,7 +22,12 @@ export default function RegisterForm() {
         login: values.login,
         password: values.password
       }).unwrap();
-      router.replace(PAGES.HOME);
+
+      // Получаем URL для перенаправления из параметров запроса
+      const returnUrl = searchParams.get('returnUrl');
+      const redirectTo = returnUrl ? decodeURIComponent(returnUrl) : PAGES.HOME;
+
+      router.replace(redirectTo);
     } catch (err) {
       console.log('Ошибка регистрации:');
       console.log(err);
@@ -77,7 +83,7 @@ export default function RegisterForm() {
           <Button block type="primary" htmlType="submit" loading={registerLoading}>
             Зарегистрироваться
           </Button>
-          или <Link href={PAGES.LOGIN}>Войти!</Link>
+          или <Link href={`${PAGES.LOGIN}${searchParams.get('returnUrl') ? `?returnUrl=${searchParams.get('returnUrl')}` : ''}`}>Войти!</Link>
         </Form.Item>
       </Form>
     </AuthWrapper>

--- a/frontend/src/components/auth-guard/AuthGuard.tsx
+++ b/frontend/src/components/auth-guard/AuthGuard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, ReactNode } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { PAGES } from '@/config/pages.config';
 import { useGetMeQuery } from '@/store/api';
 
@@ -11,13 +11,16 @@ type Props = {
 
 export function AuthGuard({ children }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
   const { data, error, isLoading } = useGetMeQuery();
 
   useEffect(() => {
     if (!isLoading && error) {
-      router.replace(PAGES.LOGIN);
+      // Сохраняем текущий путь как returnUrl для перенаправления после логина
+      const returnUrl = encodeURIComponent(pathname);
+      router.replace(`${PAGES.LOGIN}?returnUrl=${returnUrl}`);
     }
-  }, [error, isLoading, router]);
+  }, [error, isLoading, router, pathname]);
 
   // Пока грузим /me — не отображаем контент (можно вставить спиннер)
   if (isLoading) return null;


### PR DESCRIPTION
Пользователь пытается зайти на страницу, но не залогинен - теперь после логина его перекидывает на ту страницу, на которую он пытался зайти.
Работает также с ссылками приглашениями - после регистрации или входа сразу присоединяешься к мероприятию, теперь не надо ссылку ещё раз вводить