### PR TITLE
Базовые ограничения для логина и пароля

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -8,6 +8,8 @@ import { PAGES } from '@/config/pages.config';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { handleSuccessfulAuth, createAuthLinkWithReturnUrl } from '@/utils/redirect-utils';
+import { createFieldValidator } from '@/utils/validation-utils';
+import { LOGIN_VALIDATION_RULES, PASSWORD_VALIDATION_RULES } from '@/config/validation.config';
 
 export default function LoginForm() {
   const router = useRouter();
@@ -32,13 +34,19 @@ export default function LoginForm() {
       >
         <Form.Item
           name="login"
-          rules={[{ required: true, message: 'Введите логин!' }]}
+          rules={[
+            { required: true, message: 'Введите логин!' },
+            { validator: createFieldValidator(LOGIN_VALIDATION_RULES) }
+          ]}
         >
           <Input prefix={<UserOutlined />} placeholder="Логин" />
         </Form.Item>
         <Form.Item
           name="password"
-          rules={[{ required: true, message: 'Введите пароль!' }]}
+          rules={[
+            { required: true, message: 'Введите пароль!' },
+            { validator: createFieldValidator(PASSWORD_VALIDATION_RULES) }
+          ]}
         >
           <Input prefix={<LockOutlined />} type="password" placeholder="Пароль" />
         </Form.Item>

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -8,6 +8,8 @@ import { PAGES } from '@/config/pages.config';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { handleSuccessfulAuth, createAuthLinkWithReturnUrl } from '@/utils/redirect-utils';
+import { createFieldValidator } from '@/utils/validation-utils';
+import { LOGIN_VALIDATION_RULES, PASSWORD_VALIDATION_RULES } from '@/config/validation.config';
 
 export default function RegisterForm() {
   const router = useRouter();
@@ -46,12 +48,21 @@ export default function RegisterForm() {
 
         <Form.Item
           name="login"
-          rules={[{ required: true, message: 'Введите логин!' }]}
+          rules={[
+            { required: true, message: 'Введите логин!' },
+            { validator: createFieldValidator(LOGIN_VALIDATION_RULES) }
+          ]}
         >
           <Input prefix={<UserOutlined />} placeholder="Логин" />
         </Form.Item>
 
-        <Form.Item name="password" rules={[{ required: true }]}>
+        <Form.Item
+          name="password"
+          rules={[
+            { required: true, message: 'Введите пароль!' },
+            { validator: createFieldValidator(PASSWORD_VALIDATION_RULES) }
+          ]}
+        >
           <Input prefix={<LockOutlined />} type="password" placeholder="Пароль" />
         </Form.Item>
 

--- a/frontend/src/config/validation.config.ts
+++ b/frontend/src/config/validation.config.ts
@@ -1,0 +1,26 @@
+export interface ValidationRule {
+    pattern: RegExp;
+    message: string;
+}
+
+export const LOGIN_VALIDATION_RULES: ValidationRule[] = [
+    {
+        pattern: /.{4,}/,
+        message: 'Логин должен содержать минимум 4 символа',
+    },
+    {
+        pattern: /^[a-zA-Z0-9]+$/,
+        message: 'Логин может содержать только латинские буквы и цифры',
+    },
+];
+
+export const PASSWORD_VALIDATION_RULES: ValidationRule[] = [
+    {
+        pattern: /.{8,}/,
+        message: 'Пароль должен содержать минимум 8 символов',
+    },
+    {
+        pattern: /^[a-zA-Z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+$/,
+        message: 'Пароль может содержать только латинские буквы, цифры и некоторые специальные символы',
+    },
+]; 

--- a/frontend/src/utils/validation-utils.ts
+++ b/frontend/src/utils/validation-utils.ts
@@ -1,0 +1,25 @@
+import { ValidationRule } from '@/config/validation.config';
+
+export const validateField = (value: string, rules: ValidationRule[]): string | undefined => {
+    if (!value) {
+        return undefined; // Пустые значения обрабатываются отдельным правилом required
+    }
+
+    for (const rule of rules) {
+        if (!rule.pattern.test(value)) {
+            return rule.message;
+        }
+    }
+
+    return undefined;
+};
+
+export const createFieldValidator = (rules: ValidationRule[]) => {
+    return (_: any, value: string) => {
+        const error = validateField(value, rules);
+        if (error) {
+            return Promise.reject(new Error(error));
+        }
+        return Promise.resolve();
+    };
+}; 


### PR DESCRIPTION
Ограничения вместе с сообщениями прописаны в `frontend\src\config\validation.config.ts`. На бэкенде их нужно продублировать:

```typescript
export const LOGIN_VALIDATION_RULES: ValidationRule[] = [
    {
        pattern: /.{4,}/,
        message: 'Логин должен содержать минимум 4 символа',
    },
    {
        pattern: /^[a-zA-Z0-9]+$/,
        message: 'Логин может содержать только латинские буквы и цифры',
    },
];

export const PASSWORD_VALIDATION_RULES: ValidationRule[] = [
    {
        pattern: /.{8,}/,
        message: 'Пароль должен содержать минимум 8 символов',
    },
    {
        pattern: /^[a-zA-Z0-9!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+$/,
        message: 'Пароль может содержать только латинские буквы, цифры и некоторые специальные символы',
    },
]; 
```