### PR TITLE
Update logger aspects for renamed services

### DIFF
--- a/backend/src/main/java/com/github/giga_chill/gigachill/aspect/EventServiceLoggerAspect.java
+++ b/backend/src/main/java/com/github/giga_chill/gigachill/aspect/EventServiceLoggerAspect.java
@@ -45,10 +45,6 @@ public class EventServiceLoggerAspect {
                     + "&& args(eventId, ..)")
     public void updateEvent(UUID eventId) {}
 
-    @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.EventService.isExisted(..)) "
-                    + "&& args(eventId)")
-    public void isExisted(UUID eventId) {}
 
     @Pointcut(
             "execution(public * com.github.giga_chill.gigachill.service.EventService.createInviteLink(..)) "
@@ -80,10 +76,6 @@ public class EventServiceLoggerAspect {
                     + "&& args(eventId, ..)")
     public void finalizeEvent(UUID eventId) {}
 
-    @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.EventService.isFinalized(..)) "
-                    + "&& args(eventId)")
-    public void isFinalized(UUID eventId) {}
 
     @Around("createEvent(userId, requestEventInfo)")
     public Object logCreateEvent(
@@ -173,30 +165,6 @@ public class EventServiceLoggerAspect {
         }
     }
 
-    @Around("isExisted(eventId)")
-    public Object logIsExisted(ProceedingJoinPoint proceedingJoinPoint, UUID eventId)
-            throws Throwable {
-        try {
-            Object result = proceedingJoinPoint.proceed();
-            if ((Boolean) result) {
-                LOGGER.info(
-                        loggerColorConfig.getGET_COLOR()
-                                + loggerColorConfig.getGET_LABEL()
-                                + "Event with id: {} exists"
-                                + loggerColorConfig.getRESET_COLOR(),
-                        eventId);
-            } else {
-                LOGGER.info(
-                        loggerColorConfig.getGET_COLOR()
-                                + "Event with id: {} does not exist"
-                                + loggerColorConfig.getRESET_COLOR(),
-                        eventId);
-            }
-            return result;
-        } catch (Throwable ex) {
-            throw ex;
-        }
-    }
 
     @Around("createInviteLink(eventId, ..)")
     public Object logCreateInviteLink(ProceedingJoinPoint proceedingJoinPoint, UUID eventId)
@@ -307,32 +275,6 @@ public class EventServiceLoggerAspect {
                             + "Event with id: {} was finalized"
                             + loggerColorConfig.getRESET_COLOR(),
                     eventId);
-            return result;
-        } catch (Throwable ex) {
-            throw ex;
-        }
-    }
-
-    @Around("isFinalized(eventId)")
-    public Object logIsFinalized(ProceedingJoinPoint proceedingJoinPoint, UUID eventId)
-            throws Throwable {
-        try {
-            Object result = proceedingJoinPoint.proceed();
-            if ((Boolean) result) {
-                LOGGER.info(
-                        loggerColorConfig.getGET_COLOR()
-                                + loggerColorConfig.getGET_LABEL()
-                                + "Event with id: {} has status finalized"
-                                + loggerColorConfig.getRESET_COLOR(),
-                        eventId);
-            } else {
-                LOGGER.info(
-                        loggerColorConfig.getGET_COLOR()
-                                + loggerColorConfig.getGET_LABEL()
-                                + "Event with id: {} has status not finalized"
-                                + loggerColorConfig.getRESET_COLOR(),
-                        eventId);
-            }
             return result;
         } catch (Throwable ex) {
             throw ex;

--- a/backend/src/main/java/com/github/giga_chill/gigachill/aspect/ParticipantServiceLoggerAspect.java
+++ b/backend/src/main/java/com/github/giga_chill/gigachill/aspect/ParticipantServiceLoggerAspect.java
@@ -21,48 +21,48 @@ public class ParticipantServiceLoggerAspect {
     private final LoggerColorConfig loggerColorConfig;
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.getAllParticipantsByEventId(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.getAllParticipantsByEventId(..)) "
                     + "&& args(eventId, ..)")
     public void getAllParticipantsByEventId(UUID eventId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.addParticipantToEvent(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.addParticipantToEvent(..)) "
                     + "&& args(eventId, ..)")
     public void addParticipantToEvent(UUID eventId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.deleteParticipant(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.deleteParticipant(..)) "
                     + "&& args(eventId, participantId, ..)")
     public void deleteParticipant(UUID eventId, UUID participantId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.isParticipant(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.isParticipant(..)) "
                     + "&& args(eventId, userId)")
     public void isParticipant(UUID eventId, UUID userId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.updateParticipantRole(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.updateParticipantRole(..)) "
                     + "&& args(eventId, userId, participantId, body)")
     public void updateParticipantRole(
             UUID eventId, UUID userId, UUID participantId, Map<String, Object> body) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.getParticipantRoleInEvent(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.getParticipantRoleInEvent(..)) "
                     + "&& args(eventId, participantId)")
     public void getParticipantRoleInEvent(UUID eventId, UUID participantId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.getParticipantById(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.getParticipantById(..)) "
                     + "&& args(eventId, participantId)")
     public void getParticipantById(UUID eventId, UUID participantId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.getParticipantBalance(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.getParticipantBalance(..)) "
                     + "&& args(eventId, participantId)")
     public void getParticipantBalance(UUID eventId, UUID participantId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ParticipantsService.getParticipantsSummaryBalance(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ParticipantService.getParticipantsSummaryBalance(..)) "
                     + "&& args(eventId)")
     public void getParticipantsSummaryBalance(UUID eventId) {}
 

--- a/backend/src/main/java/com/github/giga_chill/gigachill/aspect/ShoppingListServiceLoggerAspect.java
+++ b/backend/src/main/java/com/github/giga_chill/gigachill/aspect/ShoppingListServiceLoggerAspect.java
@@ -22,96 +22,96 @@ public class ShoppingListServiceLoggerAspect {
     private final LoggerColorConfig loggerColorConfig;
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.getAllShoppingListsFromEvent(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.getAllShoppingListsFromEvent(..)) "
                     + "&& args(eventId, ..)")
     public void getAllShoppingListsFromEvent(UUID eventId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.getShoppingListById(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.getShoppingListById(..)) "
                     + "&& args(shoppingListId)")
     public void getShoppingListById(UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.createShoppingList(..))")
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.createShoppingList(..))")
     public void createShoppingList() {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.updateShoppingList(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.updateShoppingList(..)) "
                     + "&& args(eventId, userId, shoppingListId, ..)")
     public void updateShoppingList(UUID eventId, UUID userId, UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.deleteShoppingList(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.deleteShoppingList(..)) "
                     + "&& args(shoppingListId, ..)")
     public void deleteShoppingList(UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.addShoppingItem(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.addShoppingItem(..)) "
                     + "&& args(shoppingListId, ..)")
     public void addShoppingItem(UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.updateShoppingItem(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.updateShoppingItem(..)) "
                     + "&& args(shoppingItemId, ..)")
     public void updateShoppingItem(UUID shoppingItemId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.deleteShoppingItemFromShoppingList(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.deleteShoppingItemFromShoppingList(..)) "
                     + "&& args(shoppingListId, shoppingItemId, ..)")
     public void deleteShoppingItemFromShoppingList(UUID shoppingListId, UUID shoppingItemId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.updateShoppingItemStatus(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.updateShoppingItemStatus(..)) "
                     + "&& args(shoppingItemId, ..)")
     public void updateShoppingItemStatus(UUID shoppingItemId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.getShoppingItemById(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.getShoppingItemById(..)) "
                     + "&& args(shoppingItemId)")
     public void getShoppingItemById(UUID shoppingItemId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.updateShoppingListConsumers(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.updateShoppingListConsumers(..)) "
                     + "&& args(shoppingListId, ..)")
     public void updateShoppingListConsumers(UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.getShoppingListStatus(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.getShoppingListStatus(..)) "
                     + "&& args(shoppingListId)")
     public void getShoppingListStatus(UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.isExisted(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.isExisted(..)) "
                     + "&& args(shoppingListId)")
     public void isExisted(UUID shoppingListId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.isConsumer(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.isConsumer(..)) "
                     + "&& args(shoppingListId, consumerId)")
     public void isConsumer(UUID shoppingListId, UUID consumerId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.isShoppingItemExisted(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.isShoppingItemExisted(..)) "
                     + "&& args(shoppingItemId)")
     public void isShoppingItemExisted(UUID shoppingItemId) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.getShoppingListsByIds(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.getShoppingListsByIds(..)) "
                     + "&& args(shoppingListsIds)")
     public void getShoppingListsByIds(List<UUID> shoppingListsIds) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.areExisted(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.areExisted(..)) "
                     + "&& args(shoppingListsIds)")
     public void areExisted(List<UUID> shoppingListsIds) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.canBindShoppingListsToTask(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.canBindShoppingListsToTask(..)) "
                     + "&& args(shoppingListsIds, ..)")
     public void canBindShoppingListsToTask(List<UUID> shoppingListsIds) {}
 
     @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListsService.setBudget(..)) "
+            "execution(public * com.github.giga_chill.gigachill.service.ShoppingListService.setBudget(..)) "
                     + "&& args(shoppingListId, ..)")
     public void setBudget(UUID shoppingListId) {}
 

--- a/backend/src/main/java/com/github/giga_chill/gigachill/aspect/TaskServiceLoggerAspect.java
+++ b/backend/src/main/java/com/github/giga_chill/gigachill/aspect/TaskServiceLoggerAspect.java
@@ -65,10 +65,6 @@ public class TaskServiceLoggerAspect {
                     + "&& args(eventID, taskId)")
     public void isExisted(UUID eventID, UUID taskId) {}
 
-    @Pointcut(
-            "execution(public * com.github.giga_chill.gigachill.service.TaskService.canExecute(..)) "
-                    + "&& args(taskId, userId)")
-    public void canExecute(UUID taskId, UUID userId) {}
 
     @Pointcut(
             "execution(public * com.github.giga_chill.gigachill.service.TaskService.getExecutorId(..)) "
@@ -275,33 +271,6 @@ public class TaskServiceLoggerAspect {
         }
     }
 
-    @Around("canExecute(taskId, userId)")
-    public Object logCanExecute(ProceedingJoinPoint proceedingJoinPoint, UUID taskId, UUID userId)
-            throws Throwable {
-        try {
-            Object result = proceedingJoinPoint.proceed();
-            if ((Boolean) result) {
-                LOGGER.info(
-                        loggerColorConfig.getGET_COLOR()
-                                + loggerColorConfig.getGET_LABEL()
-                                + "User with id: {} can execute task with id: {}"
-                                + loggerColorConfig.getRESET_COLOR(),
-                        userId,
-                        taskId);
-            } else {
-                LOGGER.info(
-                        loggerColorConfig.getGET_COLOR()
-                                + loggerColorConfig.getGET_LABEL()
-                                + "User with id: {} can not execute task with id: {}"
-                                + loggerColorConfig.getRESET_COLOR(),
-                        userId,
-                        taskId);
-            }
-            return result;
-        } catch (Throwable ex) {
-            throw ex;
-        }
-    }
 
     @Around("getExecutorId(taskId)")
     public Object logGetExecutorId(ProceedingJoinPoint proceedingJoinPoint, UUID taskId)


### PR DESCRIPTION
## Summary
- rename `ParticipantsService` pointcuts to `ParticipantService`
- rename `ShoppingListsService` pointcuts to `ShoppingListService`
- remove obsolete `isExisted` and `isFinalized` logging in `EventServiceLoggerAspect`
- drop logging for removed `TaskService.canExecute` method

## Testing
- `./gradlew build -x test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a56930f448326ba19fa39ff58f573